### PR TITLE
Utility task

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A command line task running in an A2 module that can "see" all of the schemas fo
 
 Iterates over all of these and adds a `schema.js` file in the A3 format in every custom module. You can change the parent folder name of modules. By default, it is `lib/modules`.
 
+**Pay attention, the script will overwrite existing `schema.js` files in your modules directories.**
+
 The directory structure would look like:
 
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ module.exports = {
 };
 ```
 
-This greatly helps with A2 to A3 migration although it miss things like fields being optional based on module.
+This greatly helps with A2 to A3 migration although manual review is required because it does not understand:
+
+- Fields being optional based beforeConstruct logic
+- Fields being inherited from a base class module like apostrophe-pieces, i.e. not necessary to redefine them in a subclass
+- Fields being removed via removeFields
+- Fields that no longer generally exist in A3, e.g. published
 
 If a module has a self.schema property, this code should generate a new schema from it.

--- a/README.md
+++ b/README.md
@@ -2,27 +2,37 @@
 
 A command line task running in an A2 module that can "see" all of the schemas for all of the defined doc and widget types, their sub-array and object fields, et cetera.
 
-Iterates over all of these and prepares a folder with schemas in the A3 format, broken down in a sensible directory structure. You would be required to specify a folder name as the parent for these.
+Iterates over all of these and adds a `schema.js` file in the A3 format in every custom module. You can change the parent folder name of modules. By default, it is `lib/modules`.
 
 The directory structure would look like:
 
+```
 modules
-  default-page
+  custom-module
     schema.js
+  custom-page
+    schema.js
+  custom-widget
+   schema.js
+```
 
 Inside each one the format would be:
 
+```js
 module.exports = (self, options) => {
   return {
     ... a3 fields here
   };
 };
+```
 
-This makes it easy to pull into default-page/index.js:
+This makes it easy to pull into custom-module/index.js:
 
+```js
 module.exports = {
-  fields(self, options) => require('./schemas.js')(self, options)
+  fields(self, options) => require('./schema.js')(self, options)
 };
+```
 
 This greatly helps with A2 to A3 migration although it miss things like fields being optional based on module.
 

--- a/config.js
+++ b/config.js
@@ -1,0 +1,25 @@
+module.exports = {
+  moduleTypes: {
+    'apostrophe-widgets': '@apostrophecms/widget-type',
+    'apostrophe-custom-pages': '@apostrophecms/page-type',
+    'apostrophe-pieces': '@apostrophecms/piece-type',
+    'apostrophe-pieces-pages': '@apostrophecms/piece-page-type',
+    'apostrophe-any-page-manager': '@apostrophecms/any-page-type',
+    'apostrophe-global': '@apostrophecms/global',
+    'apostrophe-polymorphic-manager': '@apostrophecms/polymorphic-type',
+    'apostrophe-pages': '@apostrophecms/page'
+  },
+
+  relationshipTypes: {
+    joinByArray: 'relationship',
+    joinByOne: 'relationship',
+    joinByArrayReverse: 'relationshipReverse',
+    joinByOneReverse: 'relationshipReverse'
+  },
+
+  widgetTypes: {
+    'apostrophe-rich-text': '@apostrophecms/rich-text',
+    'apostrophe-video': '@apostrophecms/video',
+    'apostrophe-images': '@apostrophecms/image'
+  }
+};

--- a/helpers.js
+++ b/helpers.js
@@ -18,7 +18,7 @@ function handleFieldType(field) {
   return newField;
 }
 
-function handleArray (field) {
+function handleArray(field) {
   const schema =
       field.type === 'tags'
         ? [
@@ -53,7 +53,7 @@ function handleArray (field) {
 
 }
 
-function handleArea (field) {
+function handleArea(field) {
   const widgets = Object.keys(field.options.widgets).reduce((widgetAcc, widgetCur) => {
     if (widgetTypes[widgetCur]) {
       const newWidgetName = widgetTypes[widgetCur];
@@ -70,36 +70,26 @@ function handleArea (field) {
   };
 }
 
-function handleRelationship(field) {
-  let max, builders;
-  const type = relationshipTypes[field.type];
+function handleRelationship({
+  filters, type, withType, ...newField
+}) {
+  newField.type = relationshipTypes[type];
 
-  if (field.type.includes('joinByOne')) {
-    max = 1;
+  if (type.includes('joinByOne')) {
+    newField.max = 1;
   }
 
-  if (field.filters) {
-    builders = field.filters;
-
-    if (field.filters.projection) {
-      builders.project = field.filters.projection;
-      builders.projection = undefined;
-    }
-
-    field.filters = undefined;
+  if (filters) {
+    const { projection, ...builders } = filters;
+    newField.builders = builders;
+    newField.builders.project = projection;
   }
 
-  const withType = field?.withType?.startsWith('apostrophe-')
-    ? `@apostrophecms/${field.withType.slice('apostrophe-'.length)}`
-    : field.withType;
+  newField.withType = withType?.startsWith('apostrophe-')
+    ? `@apostrophecms/${withType.slice('apostrophe-'.length)}`
+    : withType;
 
-  return {
-    ...field,
-    max,
-    type,
-    builders,
-    withType
-  };
+  return newField;
 }
 
 function groupField(groups, group, fieldName) {
@@ -114,7 +104,7 @@ function groupField(groups, group, fieldName) {
 }
 
 function writeFile(folder, moduleName, moduleTypeInA3, fields) {
-  fs.writeFile(
+  return fs.writeFile(
     `${folder}/${moduleName}/schema.js`,
     prettier.format(
       `

--- a/helpers.js
+++ b/helpers.js
@@ -85,6 +85,8 @@ function handleRelationship(field) {
       builders.project = field.filters.projection;
       builders.projection = undefined;
     }
+
+    field.filters = undefined;
   }
 
   const withType = field?.withType?.startsWith('apostrophe-')

--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,128 @@
+const fs = require('fs/promises');
+const prettier = require('prettier');
+const { relationshipTypes, widgetTypes } = require('./config');
+
+function handleArray ({
+  acc, cur, name, props, keepTags
+}) {
+  if (keepTags || cur.type === 'array') {
+    const schema =
+      cur.type === 'tags'
+        ? [
+          {
+            name,
+            ...props,
+            type: 'string',
+            label: 'Tag'
+          }
+        ]
+        : props.schema;
+
+    const arrayFields = schema.reduce(
+      (arrayAcc, arrayCur) => {
+        const {
+          name, moduleName, ...arrayProps
+        } = arrayCur;
+
+        const newArrayProps = checkAreaOrRelationship(arrayCur, arrayProps);
+
+        arrayAcc.add[name] = newArrayProps;
+        return arrayAcc;
+      },
+      { add: {} }
+    );
+
+    acc[name] = {
+      type: 'array',
+      label: props.label,
+      fields: arrayFields
+    };
+  }
+
+  return acc;
+}
+
+function handleArea (props) {
+  return Object.keys(props.options.widgets).reduce((widgetAcc, widgetCur) => {
+    if (widgetTypes[widgetCur]) {
+      const newWidgetName = widgetTypes[widgetCur];
+      widgetAcc[newWidgetName] = props.options.widgets[widgetCur];
+    }
+    return widgetAcc;
+  }, {});
+}
+
+function handleRelationship(cur) {
+  let max, builders, filters;
+  const type = relationshipTypes[cur.type];
+
+  if (cur.type.includes('joinByOne')) {
+    max = 1;
+  }
+
+  if (cur.filters) {
+    builders = cur.filters;
+
+    if (cur.filters.projection) {
+      builders.project = cur.filters.projection;
+      builders.projection = undefined;
+    }
+
+    filters = undefined;
+  }
+
+  const withType = cur?.withType?.startsWith('apostrophe-')
+    ? `@apostrophecms/${cur.withType.slice('apostrophe-'.length)}`
+    : cur.withType;
+
+  return {
+    max,
+    type,
+    builders,
+    filters,
+    withType
+  };
+}
+
+function checkAreaOrRelationship(field, props) {
+  if (field.type === 'area') {
+    props.options.widgets = handleArea(props);
+  } else if (relationshipTypes[field.type]) {
+    Object.assign(props, handleRelationship(field));
+  }
+
+  return props;
+}
+
+function writeFile(folder, moduleName, moduleTypeInA3, fields) {
+  fs.writeFile(
+    `${folder}/${moduleName}/schema.js`,
+    prettier.format(
+      `
+      module.exports = (self, options) => {
+        return {
+          extend: '${moduleTypeInA3}',
+          options: {
+            label: '${moduleName}',
+          },
+          fields: {
+            add: ${JSON.stringify(fields, null, 2)}
+          }
+        };
+      };
+    `,
+      {
+        singleQuote: true,
+        parser: 'babel'
+      }
+    )
+  );
+}
+
+module.exports = {
+  writeFile,
+  handleArea,
+  handleArray,
+  handleRelationship,
+  checkAreaOrRelationship
+};

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ const {
   moduleTypes, relationshipTypes, widgetTypes
 } = require('./config');
 
-// relationship with @apostrophecms/page
 module.exports = {
   alias: 'a3SchemaExporter',
   construct(self, options) {

--- a/index.js
+++ b/index.js
@@ -57,15 +57,12 @@ module.exports = {
                 props,
                 keepTags
               });
-            } else {
-              if (cur.type === 'area') {
-                props.options.widgets = self.handleArea(props);
-              } else if (relationshipTypes[cur.type]) {
-                Object.assign(props, self.handleRelationship(cur));
-              }
 
-              acc[name] = props;
+              return acc;
             }
+
+            const newProps = self.checkAreaOrRelationship(cur, props);
+            acc[name] = newProps;
 
             return acc;
           }, {});
@@ -97,13 +94,9 @@ module.exports = {
               name, moduleName, ...arrayProps
             } = arrayCur;
 
-            if (arrayCur.type === 'area') {
-              arrayProps.options.widgets = self.handleArea(arrayProps);
-            } else if (relationshipTypes[arrayCur.type]) {
-              Object.assign(arrayProps, self.handleRelationship(arrayCur));
-            }
+            const newArrayProps = self.checkAreaOrRelationship(arrayCur, arrayProps);
 
-            arrayAcc.add[name] = arrayProps;
+            arrayAcc.add[name] = newArrayProps;
             return arrayAcc;
           },
           { add: {} }
@@ -117,6 +110,16 @@ module.exports = {
       }
 
       return acc;
+    };
+
+    self.checkAreaOrRelationship = (field, props) => {
+      if (field.type === 'area') {
+        props.options.widgets = self.handleArea(props);
+      } else if (relationshipTypes[field.type]) {
+        Object.assign(props, self.handleRelationship(field));
+      }
+
+      return props;
     };
 
     self.handleArea = (props) => {
@@ -148,7 +151,7 @@ module.exports = {
         filters = undefined;
       }
 
-      const withType = cur?.withType.startsWith('apostrophe-')
+      const withType = cur?.withType?.startsWith('apostrophe-')
         ? `@apostrophecms/${cur.withType.slice('apostrophe-'.length)}`
         : cur.withType;
 

--- a/index.js
+++ b/index.js
@@ -36,8 +36,7 @@ module.exports = {
 
           const moduleName = aposModule.schema[0].moduleName;
           if (
-            moduleTypeInA2 &&
-              moduleTypeInA2.name &&
+            moduleTypeInA2?.name &&
               moduleName &&
               (await fs.stat(`${folder}/${moduleName}`))
           ) {

--- a/index.js
+++ b/index.js
@@ -1,1 +1,84 @@
-module.exports = {};
+const fs = require('fs-extra');
+const { stripIndent } = require('common-tags');
+
+module.exports = {
+  construct(self, options) {
+    self.addTask(
+      'export',
+      stripIndent`
+        Exports A2 schemas to A3 format.
+
+        Optional argument: folder name relative to root where to search for modules. By default, it is "lib/modules".
+      `,
+      async (apos, argv) => {
+        let folder = 'lib/modules';
+        if (argv._[1]) {
+          folder = argv._[1];
+        }
+        for (const aposModule of Object.values(apos.modules)) {
+          if (
+            aposModule.schema &&
+            aposModule.schema.length
+          ) {
+
+            const moduleName = aposModule.schema[0].moduleName;
+            if (moduleName && await fs.pathExists(`${folder}/${moduleName}`)) {
+              const fields = aposModule.schema.reduce((acc, cur) => {
+                const {
+                  sortify, group, moduleName, name, checkTaken, ...props
+                } = cur;
+                acc[name] = props;
+                return acc;
+              }, {});
+
+              // eslint-disable-next-line no-inner-declarations
+              function convertObjToString(obj) {
+                return Object
+                  .entries(obj)
+                  .reduce((acc, cur) => {
+                    if (
+                      typeof cur[1] === 'object' &&
+                      cur[1] !== null &&
+                      !Array.isArray(cur[1])
+                    ) {
+                      acc += cur[0].includes('-')
+                        ? `
+                          '${cur[0]}':  {${convertObjToString(cur[1])}
+                          },
+                      `
+                        : `
+                        ${cur[0]}:  {${convertObjToString(cur[1])}
+                      },`;
+                    } else {
+                      acc += cur[0].includes('-')
+                        ? `'${cur[0]}': '${cur[1]}',`
+                        : `
+                            ${cur[0]}: '${cur[1]}',`;
+                    }
+                    return acc;
+                  }, '');
+              }
+
+              await fs.outputFile(
+                `${folder}/${moduleName}/schema.js`,
+                stripIndent`
+                  module.exports = (self, options) => {
+                    return {
+                      extend: '@apostrophecms/piece-type',
+                      options: {
+                        label: '${moduleName}',
+                      },
+                      fields: {
+                        add: { ${convertObjToString(fields)} }
+                      }
+                    };
+                  };
+                `
+              );
+            }
+          }
+        }
+      }
+    );
+  }
+};

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ module.exports = {
               (await fs.stat(`${folder}/${moduleName}`))
           ) {
             const moduleTypeInA3 = moduleTypes[moduleTypeInA2.name];
+
             const fields = aposModule.schema.reduce((acc, cur) => {
               const {
                 sortify, group, moduleName, name, checkTaken, ...props

--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 const fs = require('fs-extra');
-const { stripIndent } = require('common-tags');
 const prettier = require('prettier');
+const { stripIndent } = require('common-tags');
 const {
   moduleTypes, relationshipTypes, widgetTypes
 } = require('./config');
 
+// relationship with @apostrophecms/page
 module.exports = {
+  alias: 'a3SchemaExporter',
   construct(self, options) {
     self.addTask(
       'export',
@@ -16,61 +18,62 @@ module.exports = {
         * --folder: folder name relative to root where to search for modules. By default, it is "lib/modules". Usage: --folder=src/lib/modules
         * --keepTags: A3 does not have a "tags" field type anymore. If true, convert tags to an array containing strings. By default, false (tags are not kept). Usage: --keepTags
       `,
-      async (apos, argv) => {
-        const { folder = 'lib/modules', keepTags } = argv;
+      (apos, argv) => self.exportSchemas(apos, argv)
+    );
 
-        for (const aposModule of Object.values(apos.modules)) {
-          const nativeModules = [ 'apostrophe-', '-auto-pages' ];
-          const isCustomModule = !nativeModules.some(nativeModule => {
-            return aposModule.__meta.name.includes(nativeModule);
-          });
+    self.exportSchemas = async (apos, argv) => {
+      const { folder = 'lib/modules', keepTags } = argv;
 
-          if (isCustomModule && aposModule.schema && aposModule.schema.length) {
-            const moduleTypeInA2 = aposModule.__meta.chain
-              .reverse()
-              .find(element => Object.keys(moduleTypes).find(type => element.name === type));
+      for (const aposModule of Object.values(apos.modules)) {
+        const nativeModules = [ 'apostrophe-', '-auto-pages' ];
+        const isCustomModule = !nativeModules.some(nativeModule => {
+          return aposModule.__meta.name.includes(nativeModule);
+        });
 
-            const moduleName = aposModule.schema[0].moduleName;
-            if (
-              moduleTypeInA2 && moduleTypeInA2.name &&
-              moduleName &&
-              (await fs.pathExists(`${folder}/${moduleName}`))
-            ) {
-              const moduleTypeInA3 = moduleTypes[moduleTypeInA2.name];
-              const fields = aposModule.schema.reduce((acc, cur) => {
-                const {
-                  sortify,
-                  group,
-                  moduleName,
-                  name,
-                  checkTaken,
-                  ...props
-                } = cur;
+        if (isCustomModule && aposModule.schema && aposModule.schema.length) {
+          const moduleTypeInA2 = aposModule.__meta.chain
+            .reverse()
+            .find(element => Object.keys(moduleTypes).find(type => element.name === type));
 
-                if (cur.type === 'tags' || cur.type === 'array') {
-                  acc = handleArray(acc, cur, name, props, keepTags);
-                } else {
-                  if (cur.type === 'area') {
-                    props.options.widgets = handleArea(props);
-                  } else if (relationshipTypes[cur.type]) {
-                    Object.assign(props, handleRelationship(cur));
-                  }
+          const moduleName = aposModule.schema[0].moduleName;
+          if (
+            moduleTypeInA2 && moduleTypeInA2.name &&
+            moduleName &&
+            (await fs.pathExists(`${folder}/${moduleName}`))
+          ) {
+            const moduleTypeInA3 = moduleTypes[moduleTypeInA2.name];
+            const fields = aposModule.schema.reduce((acc, cur) => {
+              const {
+                sortify,
+                group,
+                moduleName,
+                name,
+                checkTaken,
+                ...props
+              } = cur;
 
-                  acc[name] = props;
+              if (cur.type === 'tags' || cur.type === 'array') {
+                acc = self.handleArray(acc, cur, name, props, keepTags);
+              } else {
+                if (cur.type === 'area') {
+                  props.options.widgets = self.handleArea(props);
+                } else if (relationshipTypes[cur.type]) {
+                  Object.assign(props, self.handleRelationship(cur));
                 }
 
-                return acc;
-              }, {});
+                acc[name] = props;
+              }
 
-              // do widgets now
-              await writeFile(folder, moduleName, moduleTypeInA3, fields);
-            }
+              return acc;
+            }, {});
+
+            await self.writeFile(folder, moduleName, moduleTypeInA3, fields);
           }
         }
       }
-    );
+    };
 
-    function handleArray(acc, cur, name, props, keepTags) {
+    self.handleArray = (acc, cur, name, props, keepTags) => {
       if (keepTags || cur.type === 'array') {
         const schema =
           cur.type === 'tags'
@@ -87,6 +90,13 @@ module.exports = {
             const {
               name, moduleName, ...arrayProps
             } = arrayCur;
+
+            if (arrayCur.type === 'area') {
+              arrayProps.options.widgets = self.handleArea(arrayProps);
+            } else if (relationshipTypes[arrayCur.type]) {
+              Object.assign(arrayProps, self.handleRelationship(arrayCur));
+            }
+
             arrayAcc.add[name] = arrayProps;
             return arrayAcc;
           },
@@ -101,35 +111,56 @@ module.exports = {
       }
 
       return acc;
-    }
+    };
 
-    function handleArea(props) {
-      const widgets = Object.keys(props.options.widgets).reduce((widgetAcc, widgetCur) => {
+    self.handleArea = (props) => {
+      return Object.keys(props.options.widgets).reduce((widgetAcc, widgetCur) => {
         if (widgetTypes[widgetCur]) {
           const newWidgetName = widgetTypes[widgetCur];
           widgetAcc[newWidgetName] = props.options.widgets[widgetCur];
         }
         return widgetAcc;
       }, {});
+    };
 
-      return widgets;
-    }
+    self.handleRelationship = (cur) => {
+      let max, builders, filters, withType;
+      const type = relationshipTypes[cur.type];
 
-    function handleRelationship(cur) {
-      let max;
       if (cur.type.includes('joinByOne')) {
         max = 1;
       }
-      const type = relationshipTypes[cur.type];
+
+      if (cur.filters) {
+        builders = cur.filters;
+
+        if (cur.filters.projection) {
+          builders.project = cur.filters.projection;
+          builders.projection = undefined;
+        }
+
+        filters = undefined;
+      }
+
+      if (cur.withType) {
+        withType = cur.withType;
+
+        if (withType.startsWith('apostrophe-')) {
+          withType = `@apostrophecms/${withType.split('apostrophe-')[1]}`;
+        }
+      }
 
       return {
         max,
-        type
+        type,
+        builders,
+        filters,
+        withType
       };
-    }
+    };
 
-    function writeFile(folder, moduleName, moduleTypeInA3, fields) {
-      return fs.outputFile(
+    self.writeFile = (folder, moduleName, moduleTypeInA3, fields) =>
+      fs.outputFile(
         `${folder}/${moduleName}/schema.js`,
         prettier.format(
           `
@@ -145,9 +176,11 @@ module.exports = {
             };
           };
         `,
-          { singleQuote: true }
+          {
+            singleQuote: true,
+            parser: 'babel'
+          }
         )
       );
-    }
   }
 };

--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
 const fs = require('fs/promises');
-const prettier = require('prettier');
 const { stripIndent } = require('common-tags');
+const { moduleTypes } = require('./config');
 const {
-  moduleTypes, relationshipTypes, widgetTypes
-} = require('./config');
+  checkAreaOrRelationship,
+  handleArray,
+  writeFile
+} = require('./helpers');
 
 module.exports = {
   construct(self, options) {
@@ -16,176 +18,58 @@ module.exports = {
         * --folder: folder name relative to root where to search for modules. By default, it is "lib/modules". Usage: --folder=src/lib/modules
         * --keepTags: A3 does not have a "tags" field type anymore. If true, convert tags to an array containing strings. By default, false (tags are not kept). Usage: --keepTags
       `,
-      (apos, argv) => self.exportSchemas(apos, argv)
-    );
+      async(apos, argv) => {
+        const { folder = 'lib/modules', keepTags } = argv;
 
-    self.exportSchemas = async (apos, argv) => {
-      const { folder = 'lib/modules', keepTags } = argv;
+        for (const aposModule of Object.values(apos.modules)) {
+          const nativeModules = [ 'apostrophe-', '-auto-pages' ];
+          const isCustomModule = !nativeModules.some(nativeModule => {
+            return aposModule.__meta.name.includes(nativeModule);
+          });
 
-      for (const aposModule of Object.values(apos.modules)) {
-        const nativeModules = [ 'apostrophe-', '-auto-pages' ];
-        const isCustomModule = !nativeModules.some(nativeModule => {
-          return aposModule.__meta.name.includes(nativeModule);
-        });
+          if (!isCustomModule || !aposModule?.schema.length) {
+            continue;
+          }
 
-        if (!isCustomModule || aposModule?.schema.length) {
-          return;
-        }
+          const moduleTypeInA2 = aposModule.__meta.chain
+            .reverse()
+            .find(element => Object.keys(moduleTypes).find(type => element.name === type));
 
-        const moduleTypeInA2 = aposModule.__meta.chain
-          .reverse()
-          .find(element => Object.keys(moduleTypes).find(type => element.name === type));
+          const moduleName = aposModule.schema[0].moduleName;
+          if (
+            moduleTypeInA2 &&
+              moduleTypeInA2.name &&
+              moduleName &&
+              (await fs.stat(`${folder}/${moduleName}`))
+          ) {
+            const moduleTypeInA3 = moduleTypes[moduleTypeInA2.name];
+            const fields = aposModule.schema.reduce((acc, cur) => {
+              const {
+                sortify, group, moduleName, name, checkTaken, ...props
+              } = cur;
 
-        const moduleName = aposModule.schema[0].moduleName;
-        if (
-          moduleTypeInA2 &&
-            moduleTypeInA2.name &&
-            moduleName &&
-            (await fs.stat(`${folder}/${moduleName}`))
-        ) {
-          const moduleTypeInA3 = moduleTypes[moduleTypeInA2.name];
-          const fields = aposModule.schema.reduce((acc, cur) => {
-            const {
-              sortify, group, moduleName, name, checkTaken, ...props
-            } = cur;
+              if (cur.type === 'tags' || cur.type === 'array') {
+                acc = handleArray({
+                  acc,
+                  cur,
+                  name,
+                  props,
+                  keepTags
+                });
 
-            if (cur.type === 'tags' || cur.type === 'array') {
-              acc = self.handleArray({
-                acc,
-                cur,
-                name,
-                props,
-                keepTags
-              });
+                return acc;
+              }
+
+              const newProps = checkAreaOrRelationship(cur, props);
+              acc[name] = newProps;
 
               return acc;
-            }
+            }, {});
 
-            const newProps = self.checkAreaOrRelationship(cur, props);
-            acc[name] = newProps;
-
-            return acc;
-          }, {});
-
-          await self.writeFile(folder, moduleName, moduleTypeInA3, fields);
-        }
-      }
-    };
-
-    self.handleArray = ({
-      acc, cur, name, props, keepTags
-    }) => {
-      if (keepTags || cur.type === 'array') {
-        const schema =
-          cur.type === 'tags'
-            ? [
-              {
-                name,
-                ...props,
-                type: 'string',
-                label: 'Tag'
-              }
-            ]
-            : props.schema;
-
-        const arrayFields = schema.reduce(
-          (arrayAcc, arrayCur) => {
-            const {
-              name, moduleName, ...arrayProps
-            } = arrayCur;
-
-            const newArrayProps = self.checkAreaOrRelationship(arrayCur, arrayProps);
-
-            arrayAcc.add[name] = newArrayProps;
-            return arrayAcc;
-          },
-          { add: {} }
-        );
-
-        acc[name] = {
-          type: 'array',
-          label: props.label,
-          fields: arrayFields
-        };
-      }
-
-      return acc;
-    };
-
-    self.checkAreaOrRelationship = (field, props) => {
-      if (field.type === 'area') {
-        props.options.widgets = self.handleArea(props);
-      } else if (relationshipTypes[field.type]) {
-        Object.assign(props, self.handleRelationship(field));
-      }
-
-      return props;
-    };
-
-    self.handleArea = (props) => {
-      return Object.keys(props.options.widgets).reduce((widgetAcc, widgetCur) => {
-        if (widgetTypes[widgetCur]) {
-          const newWidgetName = widgetTypes[widgetCur];
-          widgetAcc[newWidgetName] = props.options.widgets[widgetCur];
-        }
-        return widgetAcc;
-      }, {});
-    };
-
-    self.handleRelationship = (cur) => {
-      let max, builders, filters;
-      const type = relationshipTypes[cur.type];
-
-      if (cur.type.includes('joinByOne')) {
-        max = 1;
-      }
-
-      if (cur.filters) {
-        builders = cur.filters;
-
-        if (cur.filters.projection) {
-          builders.project = cur.filters.projection;
-          builders.projection = undefined;
-        }
-
-        filters = undefined;
-      }
-
-      const withType = cur?.withType?.startsWith('apostrophe-')
-        ? `@apostrophecms/${cur.withType.slice('apostrophe-'.length)}`
-        : cur.withType;
-
-      return {
-        max,
-        type,
-        builders,
-        filters,
-        withType
-      };
-    };
-
-    self.writeFile = (folder, moduleName, moduleTypeInA3, fields) =>
-      fs.writeFile(
-        `${folder}/${moduleName}/schema.js`,
-        prettier.format(
-          `
-          module.exports = (self, options) => {
-            return {
-              extend: '${moduleTypeInA3}',
-              options: {
-                label: '${moduleName}',
-              },
-              fields: {
-                add: ${JSON.stringify(fields, null, 2)}
-              }
-            };
-          };
-        `,
-          {
-            singleQuote: true,
-            parser: 'babel'
+            await writeFile(folder, moduleName, moduleTypeInA3, fields);
           }
-        )
-      );
+        }
+      }
+    );
   }
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "common-tags": "^1.8.2",
     "escodegen": "^2.0.0",
-    "fs-extra": "^10.1.0"
+    "fs-extra": "^10.1.0",
+    "prettier": "^2.7.1"
   },
   "devDependencies": {
     "eslint": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "A2 utility task to export schemas to A3 format",
   "main": "index.js",
   "scripts": {
-    "test": "mocha",
-    "test:cover": "nyc mocha"
+    "test": "mocha"
   },
   "author": "Apostrophe Technologies, Inc.",
   "license": "MIT",
@@ -23,7 +22,6 @@
     "eslint-config-standard": "^16.0.3",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.1",
-    "mocha": "^9.1.3",
-    "nyc": "^15.1.0"
+    "mocha": "^9.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,13 +10,10 @@
   "license": "MIT",
   "dependencies": {
     "common-tags": "^1.8.2",
-    "escodegen": "^2.0.0",
-    "fs-extra": "^10.1.0",
     "prettier": "^2.7.1"
   },
   "devDependencies": {
     "apostrophe": "^2.222.0",
-    "chai": "^4.3.6",
     "eslint": "^7.1.0",
     "eslint-config-apostrophe": "^3.4.1",
     "eslint-config-standard": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A2 utility task to export schemas to A3 format",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "eslint . && mocha"
   },
   "author": "Apostrophe Technologies, Inc.",
   "license": "MIT",
@@ -13,7 +13,6 @@
     "prettier": "^2.7.1"
   },
   "devDependencies": {
-    "apostrophe": "^2.222.0",
     "eslint": "^7.1.0",
     "eslint-config-apostrophe": "^3.4.1",
     "eslint-config-standard": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A2 utility task to export schemas to A3 format",
   "main": "index.js",
   "scripts": {
-    "test": "eslint . && mocha"
+    "test": "mocha",
+    "test:cover": "nyc mocha"
   },
   "author": "Apostrophe Technologies, Inc.",
   "license": "MIT",
@@ -15,11 +16,14 @@
     "prettier": "^2.7.1"
   },
   "devDependencies": {
+    "apostrophe": "^2.222.0",
+    "chai": "^4.3.6",
     "eslint": "^7.1.0",
     "eslint-config-apostrophe": "^3.4.1",
     "eslint-config-standard": "^16.0.3",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.1",
-    "mocha": "^9.1.3"
+    "mocha": "^9.1.3",
+    "nyc": "^15.1.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -69,13 +69,12 @@ describe('Apostrophe-a3-schema-exporter', function() {
     const name = 'content';
     const props = cur;
 
-    const generatedArray = apos.modules['apostrophe-a3-schema-exporter'].handleArray(
+    const generatedArray = apos.modules['apostrophe-a3-schema-exporter'].handleArray({
       acc,
       cur,
       name,
-      props,
-      false
-    );
+      props
+    });
 
     assert.deepEqual(generatedArray, {
       content: {
@@ -114,13 +113,13 @@ describe('Apostrophe-a3-schema-exporter', function() {
       type: 'tags',
       label: 'Tags'
     };
-    const generatedArray = apos.modules['apostrophe-a3-schema-exporter'].handleArray(
+    const generatedArray = apos.modules['apostrophe-a3-schema-exporter'].handleArray({
       acc,
       cur,
       name,
       props,
-      true
-    );
+      keepTags: true
+    });
 
     assert.deepEqual(generatedArray, {
       tags: {

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,8 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 const helpers = require('../helpers');
 
 describe('Apostrophe-a3-schema-exporter', function() {
-  it('should handle arrays', () => {
+  it('should handle arrays', function() {
     const field = {
       name: 'content-links',
       type: 'array',
@@ -40,7 +40,7 @@ describe('Apostrophe-a3-schema-exporter', function() {
     });
   });
 
-  it('should handle tags as an array', () => {
+  it('should handle tags as an array', function() {
     const field = {
       type: 'tags',
       name: 'tags',
@@ -62,7 +62,7 @@ describe('Apostrophe-a3-schema-exporter', function() {
     });
   });
 
-  it('should handle areas', async () => {
+  it('should handle areas', function() {
     const props = {
       label: 'Widgets',
       type: 'area',
@@ -89,7 +89,7 @@ describe('Apostrophe-a3-schema-exporter', function() {
     });
   });
 
-  it('should handle joinByOne', async () => {
+  it('should handle joinByOne', function() {
     const cur = {
       type: 'joinByOne',
       name: '_article',
@@ -98,14 +98,15 @@ describe('Apostrophe-a3-schema-exporter', function() {
     };
     const generatedRelationship = helpers.handleRelationship(cur);
 
-    assert(generatedRelationship, {
+    assert.deepEqual(generatedRelationship, {
+      ...generatedRelationship,
       max: 1,
       type: 'relationship'
     });
-    assert.strictEqual(generatedRelationship.filters, undefined);
+    assert.equal(generatedRelationship.filters, undefined);
   });
 
-  it('should handle joinByArray', async () => {
+  it('should handle joinByArray', function() {
     const cur = {
       type: 'joinByArray',
       name: '_articles',
@@ -114,14 +115,15 @@ describe('Apostrophe-a3-schema-exporter', function() {
     };
     const generatedRelationship = helpers.handleRelationship(cur);
 
-    assert(generatedRelationship, {
+    assert.deepEqual(generatedRelationship, {
+      ...generatedRelationship,
       type: 'relationship'
     });
-    assert.strictEqual(generatedRelationship.filters, undefined);
-    assert.strictEqual(generatedRelationship.max, undefined);
+    assert.equal(generatedRelationship.filters, undefined);
+    assert.equal(generatedRelationship.max, undefined);
   });
 
-  it('should handle reverse joins', async () => {
+  it('should handle reverse joins', function() {
     const cur = {
       type: 'joinByArrayReverse',
       name: '_articles',
@@ -132,15 +134,16 @@ describe('Apostrophe-a3-schema-exporter', function() {
     };
     const generatedRelationship = helpers.handleRelationship(cur);
 
-    assert(generatedRelationship, {
+    assert.deepEqual(generatedRelationship, {
+      ...generatedRelationship,
       type: 'relationshipReverse',
       withType: 'article'
     });
-    assert.strictEqual(generatedRelationship.filters, undefined);
-    assert.strictEqual(generatedRelationship.max, undefined);
+    assert.equal(generatedRelationship.filters, undefined);
+    assert.equal(generatedRelationship.max, undefined);
   });
 
-  it('should convert join filters to builders', () => {
+  it('should convert join filters to builders', function() {
     const cur = {
       type: 'joinByArray',
       name: '_articles',
@@ -157,22 +160,24 @@ describe('Apostrophe-a3-schema-exporter', function() {
     };
     const generatedRelationship = helpers.handleRelationship(cur);
 
-    assert(generatedRelationship, {
+    assert.deepEqual(generatedRelationship, {
+      ...generatedRelationship,
       type: 'relationship',
       withType: 'article'
     });
-    assert.strictEqual(generatedRelationship.filters, undefined);
-    assert(generatedRelationship.builders, {
+    assert.equal(generatedRelationship.filters, undefined);
+    assert.deepEqual(generatedRelationship.builders, {
+      ...generatedRelationship.builders,
       project: {
         title: 1,
         slug: 1,
         type: 1
       }
     });
-    assert.strictEqual(generatedRelationship.builders.projection, undefined);
+    assert.equal(generatedRelationship.builders.projection, undefined);
   });
 
-  it('should convert joins with A2 type to A3', () => {
+  it('should convert joins with A2 type to A3', function() {
     const cur = {
       name: '_page',
       label: 'Link',
@@ -182,13 +187,14 @@ describe('Apostrophe-a3-schema-exporter', function() {
     };
     const generatedRelationship = helpers.handleRelationship(cur);
 
-    assert(generatedRelationship, {
+    assert.deepEqual(generatedRelationship, {
+      ...generatedRelationship,
       type: 'relationship',
       withType: '@apostrophecms/page'
     });
   });
 
-  it('should add a group field', () => {
+  it('should add a group field', function() {
     const groups = {
       basics: {
         label: 'Basics',
@@ -213,7 +219,7 @@ describe('Apostrophe-a3-schema-exporter', function() {
     });
   });
 
-  it('should update a group field', () => {
+  it('should update a group field', function() {
     const groups = {
       basics: {
         label: 'Basics',

--- a/test/index.js
+++ b/test/index.js
@@ -1,54 +1,7 @@
-/* eslint-disable no-unused-expressions */
-const fs = require('fs');
 const assert = require('assert');
-const { promisify } = require('util');
-const a3SchemaExporter = require('../index');
+const helpers = require('../helpers');
 
 describe('Apostrophe-a3-schema-exporter', function() {
-  this.timeout(10000);
-  let apos;
-
-  after(async () => {
-    const destroy = promisify(require('apostrophe/test-lib/util').destroy);
-    await destroy(apos);
-    fs.rmSync('./test/locales', {
-      recursive: true,
-      force: true
-    });
-    fs.rmSync('./test/data', {
-      recursive: true,
-      force: true
-    });
-    fs.rmSync('./test/public', {
-      recursive: true,
-      force: true
-    });
-  });
-
-  before((done) => {
-    apos = require('apostrophe')({
-      migrate: false,
-      shortName: 'apostrophe-schema-exporter-test',
-      modules: {
-        'apostrophe-assets': {
-          jQuery: 3
-        },
-        'apostrophe-express': {
-          port: 3000,
-          address: 'localhost',
-          session: {
-            secret: '12345'
-          }
-        },
-        'apostrophe-images': {
-          enableAltField: true
-        },
-        'apostrophe-a3-schema-exporter': a3SchemaExporter
-      },
-      afterListen: done
-    });
-  });
-
   it('should handle arrays', () => {
     const acc = {};
     const cur = {
@@ -69,11 +22,12 @@ describe('Apostrophe-a3-schema-exporter', function() {
     const name = 'content';
     const props = cur;
 
-    const generatedArray = apos.modules['apostrophe-a3-schema-exporter'].handleArray({
+    const generatedArray = helpers.handleArray({
       acc,
       cur,
       name,
-      props
+      props,
+      keepTags: false
     });
 
     assert.deepEqual(generatedArray, {
@@ -113,7 +67,7 @@ describe('Apostrophe-a3-schema-exporter', function() {
       type: 'tags',
       label: 'Tags'
     };
-    const generatedArray = apos.modules['apostrophe-a3-schema-exporter'].handleArray({
+    const generatedArray = helpers.handleArray({
       acc,
       cur,
       name,
@@ -149,7 +103,7 @@ describe('Apostrophe-a3-schema-exporter', function() {
         }
       }
     };
-    const generatedArea = apos.modules['apostrophe-a3-schema-exporter'].handleArea(props);
+    const generatedArea = helpers.handleArea(props);
 
     assert.deepEqual(generatedArea, {
       '@apostrophecms/rich-text': { toolbar: [ 'Undo', 'Redo' ] },
@@ -165,7 +119,7 @@ describe('Apostrophe-a3-schema-exporter', function() {
       label: 'Article',
       idField: 'articleId'
     };
-    const generatedRelationship = apos.modules['apostrophe-a3-schema-exporter'].handleRelationship(cur);
+    const generatedRelationship = helpers.handleRelationship(cur);
 
     assert(generatedRelationship, {
       max: 1,
@@ -181,7 +135,7 @@ describe('Apostrophe-a3-schema-exporter', function() {
       label: 'Articles',
       idsField: 'articlesId'
     };
-    const generatedRelationship = apos.modules['apostrophe-a3-schema-exporter'].handleRelationship(cur);
+    const generatedRelationship = helpers.handleRelationship(cur);
 
     assert(generatedRelationship, {
       type: 'relationship'
@@ -199,7 +153,7 @@ describe('Apostrophe-a3-schema-exporter', function() {
       idsField: 'categoryIds',
       withType: 'article'
     };
-    const generatedRelationship = apos.modules['apostrophe-a3-schema-exporter'].handleRelationship(cur);
+    const generatedRelationship = helpers.handleRelationship(cur);
 
     assert(generatedRelationship, {
       type: 'relationshipReverse',
@@ -224,7 +178,7 @@ describe('Apostrophe-a3-schema-exporter', function() {
         }
       }
     };
-    const generatedRelationship = apos.modules['apostrophe-a3-schema-exporter'].handleRelationship(cur);
+    const generatedRelationship = helpers.handleRelationship(cur);
 
     assert(generatedRelationship, {
       type: 'relationship',
@@ -249,7 +203,7 @@ describe('Apostrophe-a3-schema-exporter', function() {
       withType: 'apostrophe-page',
       idField: 'pageId'
     };
-    const generatedRelationship = apos.modules['apostrophe-a3-schema-exporter'].handleRelationship(cur);
+    const generatedRelationship = helpers.handleRelationship(cur);
 
     assert(generatedRelationship, {
       type: 'relationship',

--- a/test/index.js
+++ b/test/index.js
@@ -3,47 +3,37 @@ const helpers = require('../helpers');
 
 describe('Apostrophe-a3-schema-exporter', function() {
   it('should handle arrays', () => {
-    const acc = {};
-    const cur = {
+    const field = {
       name: 'content-links',
       type: 'array',
-      schema: [ {
-        name: 'url',
-        label: 'Url',
-        type: 'url'
-      },
-      {
-        name: 'description',
-        label: 'Description',
-        type: 'string'
-      } ],
+      schema: [
+        {
+          name: 'url',
+          label: 'Url',
+          type: 'url'
+        },
+        {
+          name: 'description',
+          label: 'Description',
+          type: 'string'
+        }
+      ],
       label: 'Content'
     };
-    const name = 'content';
-    const props = cur;
-
-    const generatedArray = helpers.handleArray({
-      acc,
-      cur,
-      name,
-      props,
-      keepTags: false
-    });
+    const generatedArray = helpers.handleArray(field);
 
     assert.deepEqual(generatedArray, {
-      content: {
-        type: 'array',
-        label: 'Content',
-        fields: {
-          add: {
-            url: {
-              label: 'Url',
-              type: 'url'
-            },
-            description: {
-              label: 'Description',
-              type: 'string'
-            }
+      type: 'array',
+      label: 'Content',
+      fields: {
+        add: {
+          url: {
+            label: 'Url',
+            type: 'url'
+          },
+          description: {
+            label: 'Description',
+            type: 'string'
           }
         }
       }
@@ -51,40 +41,21 @@ describe('Apostrophe-a3-schema-exporter', function() {
   });
 
   it('should handle tags as an array', () => {
-    const acc = {};
-    const cur = {
+    const field = {
       type: 'tags',
       name: 'tags',
-      label: 'Tags',
-      group: {
-        name: 'basics',
-        label: 'Basics'
-      },
-      moduleName: 'categories'
-    };
-    const name = 'tags';
-    const props = {
-      type: 'tags',
       label: 'Tags'
     };
-    const generatedArray = helpers.handleArray({
-      acc,
-      cur,
-      name,
-      props,
-      keepTags: true
-    });
+    const generatedArray = helpers.handleArray(field);
 
     assert.deepEqual(generatedArray, {
-      tags: {
-        type: 'array',
-        label: 'Tags',
-        fields: {
-          add: {
-            tags: {
-              type: 'string',
-              label: 'Tag'
-            }
+      type: 'array',
+      label: 'Tags',
+      fields: {
+        add: {
+          tag: {
+            type: 'string',
+            label: 'Tag'
           }
         }
       }
@@ -106,9 +77,15 @@ describe('Apostrophe-a3-schema-exporter', function() {
     const generatedArea = helpers.handleArea(props);
 
     assert.deepEqual(generatedArea, {
-      '@apostrophecms/rich-text': { toolbar: [ 'Undo', 'Redo' ] },
-      '@apostrophecms/image': { size: 'full' },
-      '@apostrophecms/video': {}
+      label: 'Widgets',
+      type: 'area',
+      options: {
+        widgets: {
+          '@apostrophecms/rich-text': { toolbar: [ 'Undo', 'Redo' ] },
+          '@apostrophecms/image': { size: 'full' },
+          '@apostrophecms/video': {}
+        }
+      }
     });
   });
 
@@ -208,6 +185,60 @@ describe('Apostrophe-a3-schema-exporter', function() {
     assert(generatedRelationship, {
       type: 'relationship',
       withType: '@apostrophecms/page'
+    });
+  });
+
+  it('should add a group field', () => {
+    const groups = {
+      basics: {
+        label: 'Basics',
+        fields: [ 'title', 'slug', 'published' ]
+      }
+    };
+    const group = {
+      name: 'content',
+      label: 'Content'
+    };
+    const generatedGroups = helpers.groupField(groups, group, 'description');
+
+    assert.deepEqual(generatedGroups, {
+      basics: {
+        label: 'Basics',
+        fields: [ 'title', 'slug', 'published' ]
+      },
+      content: {
+        label: 'Content',
+        fields: [ 'description' ]
+      }
+    });
+  });
+
+  it('should update a group field', () => {
+    const groups = {
+      basics: {
+        label: 'Basics',
+        fields: [ 'title', 'slug', 'published' ]
+      },
+      content: {
+        label: 'Content',
+        fields: [ 'description' ]
+      }
+    };
+    const group = {
+      name: 'content',
+      label: 'Content'
+    };
+    const generatedGroups = helpers.groupField(groups, group, 'link');
+
+    assert.deepEqual(generatedGroups, {
+      basics: {
+        label: 'Basics',
+        fields: [ 'title', 'slug', 'published' ]
+      },
+      content: {
+        label: 'Content',
+        fields: [ 'description', 'link' ]
+      }
     });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-expressions */
-const fs = require('fs-extra');
-const { expect } = require('chai');
+const fs = require('fs');
+const assert = require('assert');
 const { promisify } = require('util');
 const a3SchemaExporter = require('../index');
 
@@ -11,9 +11,18 @@ describe('Apostrophe-a3-schema-exporter', function() {
   after(async () => {
     const destroy = promisify(require('apostrophe/test-lib/util').destroy);
     await destroy(apos);
-    fs.removeSync('./test/locales');
-    fs.removeSync('./test/data');
-    fs.removeSync('./test/public');
+    fs.rmSync('./test/locales', {
+      recursive: true,
+      force: true
+    });
+    fs.rmSync('./test/data', {
+      recursive: true,
+      force: true
+    });
+    fs.rmSync('./test/public', {
+      recursive: true,
+      force: true
+    });
   });
 
   before((done) => {
@@ -60,7 +69,7 @@ describe('Apostrophe-a3-schema-exporter', function() {
     const name = 'content';
     const props = cur;
 
-    const generatedArray = apos.a3SchemaExporter.handleArray(
+    const generatedArray = apos.modules['apostrophe-a3-schema-exporter'].handleArray(
       acc,
       cur,
       name,
@@ -68,7 +77,7 @@ describe('Apostrophe-a3-schema-exporter', function() {
       false
     );
 
-    expect(generatedArray).to.deep.equal({
+    assert.deepEqual(generatedArray, {
       content: {
         type: 'array',
         label: 'Content',
@@ -105,7 +114,7 @@ describe('Apostrophe-a3-schema-exporter', function() {
       type: 'tags',
       label: 'Tags'
     };
-    const generatedArray = apos.a3SchemaExporter.handleArray(
+    const generatedArray = apos.modules['apostrophe-a3-schema-exporter'].handleArray(
       acc,
       cur,
       name,
@@ -113,7 +122,7 @@ describe('Apostrophe-a3-schema-exporter', function() {
       true
     );
 
-    expect(generatedArray).to.deep.equal({
+    assert.deepEqual(generatedArray, {
       tags: {
         type: 'array',
         label: 'Tags',
@@ -141,9 +150,9 @@ describe('Apostrophe-a3-schema-exporter', function() {
         }
       }
     };
-    const generatedArea = apos.a3SchemaExporter.handleArea(props);
+    const generatedArea = apos.modules['apostrophe-a3-schema-exporter'].handleArea(props);
 
-    expect(generatedArea).to.deep.equal({
+    assert.deepEqual(generatedArea, {
       '@apostrophecms/rich-text': { toolbar: [ 'Undo', 'Redo' ] },
       '@apostrophecms/image': { size: 'full' },
       '@apostrophecms/video': {}
@@ -157,13 +166,13 @@ describe('Apostrophe-a3-schema-exporter', function() {
       label: 'Article',
       idField: 'articleId'
     };
-    const generatedRelationship = apos.a3SchemaExporter.handleRelationship(cur);
+    const generatedRelationship = apos.modules['apostrophe-a3-schema-exporter'].handleRelationship(cur);
 
-    expect(generatedRelationship).to.contain({
+    assert(generatedRelationship, {
       max: 1,
       type: 'relationship'
     });
-    expect(generatedRelationship.filters).to.be.undefined;
+    assert.strictEqual(generatedRelationship.filters, undefined);
   });
 
   it('should handle joinByArray', async () => {
@@ -173,13 +182,13 @@ describe('Apostrophe-a3-schema-exporter', function() {
       label: 'Articles',
       idsField: 'articlesId'
     };
-    const generatedRelationship = apos.a3SchemaExporter.handleRelationship(cur);
+    const generatedRelationship = apos.modules['apostrophe-a3-schema-exporter'].handleRelationship(cur);
 
-    expect(generatedRelationship).to.contain({
+    assert(generatedRelationship, {
       type: 'relationship'
     });
-    expect(generatedRelationship.filters).to.be.undefined;
-    expect(generatedRelationship.max).to.be.undefined;
+    assert.strictEqual(generatedRelationship.filters, undefined);
+    assert.strictEqual(generatedRelationship.max, undefined);
   });
 
   it('should handle reverse joins', async () => {
@@ -191,14 +200,14 @@ describe('Apostrophe-a3-schema-exporter', function() {
       idsField: 'categoryIds',
       withType: 'article'
     };
-    const generatedRelationship = apos.a3SchemaExporter.handleRelationship(cur);
+    const generatedRelationship = apos.modules['apostrophe-a3-schema-exporter'].handleRelationship(cur);
 
-    expect(generatedRelationship).to.contain({
+    assert(generatedRelationship, {
       type: 'relationshipReverse',
       withType: 'article'
     });
-    expect(generatedRelationship.filters).to.be.undefined;
-    expect(generatedRelationship.max).to.be.undefined;
+    assert.strictEqual(generatedRelationship.filters, undefined);
+    assert.strictEqual(generatedRelationship.max, undefined);
   });
 
   it('should convert join filters to builders', () => {
@@ -216,21 +225,21 @@ describe('Apostrophe-a3-schema-exporter', function() {
         }
       }
     };
-    const generatedRelationship = apos.a3SchemaExporter.handleRelationship(cur);
+    const generatedRelationship = apos.modules['apostrophe-a3-schema-exporter'].handleRelationship(cur);
 
-    expect(generatedRelationship).to.contain({
+    assert(generatedRelationship, {
       type: 'relationship',
       withType: 'article'
     });
-    expect(generatedRelationship.filters).to.be.undefined;
-    expect(generatedRelationship.builders).to.deep.nested.contain({
+    assert.strictEqual(generatedRelationship.filters, undefined);
+    assert(generatedRelationship.builders, {
       project: {
         title: 1,
         slug: 1,
         type: 1
       }
     });
-    expect(generatedRelationship.builders.projection).to.be.undefined;
+    assert.strictEqual(generatedRelationship.builders.projection, undefined);
   });
 
   it('should convert joins with A2 type to A3', () => {
@@ -241,9 +250,9 @@ describe('Apostrophe-a3-schema-exporter', function() {
       withType: 'apostrophe-page',
       idField: 'pageId'
     };
-    const generatedRelationship = apos.a3SchemaExporter.handleRelationship(cur);
+    const generatedRelationship = apos.modules['apostrophe-a3-schema-exporter'].handleRelationship(cur);
 
-    expect(generatedRelationship).to.contain({
+    assert(generatedRelationship, {
       type: 'relationship',
       withType: '@apostrophecms/page'
     });

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,251 @@
+/* eslint-disable no-unused-expressions */
+const fs = require('fs-extra');
+const { expect } = require('chai');
+const { promisify } = require('util');
+const a3SchemaExporter = require('../index');
+
+describe('Apostrophe-a3-schema-exporter', function() {
+  this.timeout(10000);
+  let apos;
+
+  after(async () => {
+    const destroy = promisify(require('apostrophe/test-lib/util').destroy);
+    await destroy(apos);
+    fs.removeSync('./test/locales');
+    fs.removeSync('./test/data');
+    fs.removeSync('./test/public');
+  });
+
+  before((done) => {
+    apos = require('apostrophe')({
+      migrate: false,
+      shortName: 'apostrophe-schema-exporter-test',
+      modules: {
+        'apostrophe-assets': {
+          jQuery: 3
+        },
+        'apostrophe-express': {
+          port: 3000,
+          address: 'localhost',
+          session: {
+            secret: '12345'
+          }
+        },
+        'apostrophe-images': {
+          enableAltField: true
+        },
+        'apostrophe-a3-schema-exporter': a3SchemaExporter
+      },
+      afterListen: done
+    });
+  });
+
+  it('should handle arrays', () => {
+    const acc = {};
+    const cur = {
+      name: 'content-links',
+      type: 'array',
+      schema: [ {
+        name: 'url',
+        label: 'Url',
+        type: 'url'
+      },
+      {
+        name: 'description',
+        label: 'Description',
+        type: 'string'
+      } ],
+      label: 'Content'
+    };
+    const name = 'content';
+    const props = cur;
+
+    const generatedArray = apos.a3SchemaExporter.handleArray(
+      acc,
+      cur,
+      name,
+      props,
+      false
+    );
+
+    expect(generatedArray).to.deep.equal({
+      content: {
+        type: 'array',
+        label: 'Content',
+        fields: {
+          add: {
+            url: {
+              label: 'Url',
+              type: 'url'
+            },
+            description: {
+              label: 'Description',
+              type: 'string'
+            }
+          }
+        }
+      }
+    });
+  });
+
+  it('should handle tags as an array', () => {
+    const acc = {};
+    const cur = {
+      type: 'tags',
+      name: 'tags',
+      label: 'Tags',
+      group: {
+        name: 'basics',
+        label: 'Basics'
+      },
+      moduleName: 'categories'
+    };
+    const name = 'tags';
+    const props = {
+      type: 'tags',
+      label: 'Tags'
+    };
+    const generatedArray = apos.a3SchemaExporter.handleArray(
+      acc,
+      cur,
+      name,
+      props,
+      true
+    );
+
+    expect(generatedArray).to.deep.equal({
+      tags: {
+        type: 'array',
+        label: 'Tags',
+        fields: {
+          add: {
+            tags: {
+              type: 'string',
+              label: 'Tag'
+            }
+          }
+        }
+      }
+    });
+  });
+
+  it('should handle areas', async () => {
+    const props = {
+      label: 'Widgets',
+      type: 'area',
+      options: {
+        widgets: {
+          'apostrophe-rich-text': { toolbar: [ 'Undo', 'Redo' ] },
+          'apostrophe-images': { size: 'full' },
+          'apostrophe-video': {}
+        }
+      }
+    };
+    const generatedArea = apos.a3SchemaExporter.handleArea(props);
+
+    expect(generatedArea).to.deep.equal({
+      '@apostrophecms/rich-text': { toolbar: [ 'Undo', 'Redo' ] },
+      '@apostrophecms/image': { size: 'full' },
+      '@apostrophecms/video': {}
+    });
+  });
+
+  it('should handle joinByOne', async () => {
+    const cur = {
+      type: 'joinByOne',
+      name: '_article',
+      label: 'Article',
+      idField: 'articleId'
+    };
+    const generatedRelationship = apos.a3SchemaExporter.handleRelationship(cur);
+
+    expect(generatedRelationship).to.contain({
+      max: 1,
+      type: 'relationship'
+    });
+    expect(generatedRelationship.filters).to.be.undefined;
+  });
+
+  it('should handle joinByArray', async () => {
+    const cur = {
+      type: 'joinByArray',
+      name: '_articles',
+      label: 'Articles',
+      idsField: 'articlesId'
+    };
+    const generatedRelationship = apos.a3SchemaExporter.handleRelationship(cur);
+
+    expect(generatedRelationship).to.contain({
+      type: 'relationship'
+    });
+    expect(generatedRelationship.filters).to.be.undefined;
+    expect(generatedRelationship.max).to.be.undefined;
+  });
+
+  it('should handle reverse joins', async () => {
+    const cur = {
+      type: 'joinByArrayReverse',
+      name: '_articles',
+      label: 'Articles',
+      reverseOf: '_category',
+      idsField: 'categoryIds',
+      withType: 'article'
+    };
+    const generatedRelationship = apos.a3SchemaExporter.handleRelationship(cur);
+
+    expect(generatedRelationship).to.contain({
+      type: 'relationshipReverse',
+      withType: 'article'
+    });
+    expect(generatedRelationship.filters).to.be.undefined;
+    expect(generatedRelationship.max).to.be.undefined;
+  });
+
+  it('should convert join filters to builders', () => {
+    const cur = {
+      type: 'joinByArray',
+      name: '_articles',
+      label: 'Articles',
+      idsField: 'articlesId',
+      withType: 'article',
+      filters: {
+        projection: {
+          title: 1,
+          slug: 1,
+          type: 1
+        }
+      }
+    };
+    const generatedRelationship = apos.a3SchemaExporter.handleRelationship(cur);
+
+    expect(generatedRelationship).to.contain({
+      type: 'relationship',
+      withType: 'article'
+    });
+    expect(generatedRelationship.filters).to.be.undefined;
+    expect(generatedRelationship.builders).to.deep.nested.contain({
+      project: {
+        title: 1,
+        slug: 1,
+        type: 1
+      }
+    });
+    expect(generatedRelationship.builders.projection).to.be.undefined;
+  });
+
+  it('should convert joins with A2 type to A3', () => {
+    const cur = {
+      name: '_page',
+      label: 'Link',
+      type: 'joinByOne',
+      withType: 'apostrophe-page',
+      idField: 'pageId'
+    };
+    const generatedRelationship = apos.a3SchemaExporter.handleRelationship(cur);
+
+    expect(generatedRelationship).to.contain({
+      type: 'relationship',
+      withType: '@apostrophecms/page'
+    });
+  });
+});


### PR DESCRIPTION
# A2 utility task to export schemas to A3 format

A command line task running in an A2 module that can "see" all of the schemas for all of the defined doc and widget types, their sub-array and object fields, et cetera.

Iterates over all of these and adds a `schema.js` file in the A3 format in every custom module. You can change the parent folder name of modules. By default, it is `lib/modules`.

The directory structure would look like:

```
modules
  custom-module
    schema.js
  custom-page
    schema.js
  custom-widget
   schema.js
```

To test it, you can `npm link` this module with the A2 apostrophe-boilerplate repo (https://github.com/apostrophecms/apostrophe-boilerplate) and run `node app apostrophe-a3-schema-exporter:export` provided there is at least one custom module in the boilerplate.

There is an option to pass if the project uses a different path than `lib/modules`
- folder: by default, `lib/modules`

Unit tests can also be run into this project with `npm test`